### PR TITLE
record current hostname/domain so amplitude can filter

### DIFF
--- a/src/utils/amplitude.js
+++ b/src/utils/amplitude.js
@@ -5,15 +5,15 @@ export const amplitudeInit = () => {
   a.getInstance().init("b03da34a4b82cd670be2217a0d5e0938")
 }
 
-export const amplitudeLogEvent = eventName => {
-  a.getInstance().logEvent(eventName)
+export const amplitudeLogEvent = (eventName, props) => {
+  a.getInstance().logEvent(eventName, props)
 }
 
 export const useAmplitudeLogEvent = eventName => {
   useEffect(() => {
     if (process.env.NODE_ENV !== "development") {
       amplitudeInit()
-      amplitudeLogEvent(eventName)
+      amplitudeLogEvent(eventName, { hostname: window.location.hostname })
     } else {
       console.log(`Amplitude event ${eventName} triggered.`)
     }


### PR DESCRIPTION
Right now I think the zeit deployments are being logged in amplitude, which will mess with our stats. Weirdly, Amplitude doesn't appear to log domain by default, so we include it as an event property. Then in Amplitude we can filter out events not coming from www.sandboxneu.com