### PR TITLE
Remove padding on bottom of who desktop images for better alignment

### DIFF
--- a/src/components/IndexPage/who.js
+++ b/src/components/IndexPage/who.js
@@ -29,14 +29,14 @@ const Desktop = styled.div`
 
 const ShadowImg = styled(Img)`
   box-shadow: 1px 1px 13px rgba(0, 0, 0, 0.25);
-  margin: 0px 10px;
+  margin: 0 10px;
 `
 
 const ImgContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 30px 0px;
+  padding: 30px 0 0;
 `
 
 const Who = ({ img1, img2, img3, title1, p1, title2, p2 }) => {


### PR DESCRIPTION
This PR fixes the somewhat odd current alignment in the who page shown here:

<img width="1108" alt="Screen Shot 2019-06-16 at 10 36 35 AM" src="https://user-images.githubusercontent.com/13836027/59565686-650bb800-9024-11e9-831a-d402a720a721.png">
