### PR TITLE
Remove club and core

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
   Sandbox at Northeastern
 </h1>
 
-Hi! We're __Sandbox__, a club at Northeastern University 🐾 in Boston. We enable researchers and other nonprofits to more efficiently do the wonderful things they already do by building them custom software to help with their experiments and other ventures.
+Hi! We're __Sandbox__, a student organization at Northeastern University 🐾 in Boston. We enable researchers and other nonprofits to more efficiently do the wonderful things they already do by building them custom software to help with their experiments and other ventures.
 
 This is our outward-facing website, designed and built with [Gatsby](https://github.com/gatsbyjs/gatsby/) by the Sandbox team. If you are interested in what we do, please reach out to us at info@sandboxneu.com, or fill out our [interest form](https://forms.gle/aZB5fGMEBKB4uDLU7) if you'd like to develop with us in the fall.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `Sandbox`,
-    description: `Sandbox is a club at Northeastern University that creates custom software applications for researchers.`,
+    description: `Sandbox is a student organization at Northeastern University that creates custom software applications for researchers.`,
     author: `Sandbox at Northeastern`,
     pages: [
       {

--- a/src/content/join/design.md
+++ b/src/content/join/design.md
@@ -7,6 +7,6 @@ formLink: "https://docs.google.com/forms/d/e/1FAIpQLSci8o8K8I4szGhfdqiJ5sAfB9NHg
 role: designer
 ---
 
-We’re looking for a lead designer to build up our brand identity as the club expands its presence in the Northeastern community. As design lead, you’ll work closely with our Marketing Director and Executive Director to create branded materials across our website, social media, apparel, and posters. You’ll also work alongside our Core team and the researchers to craft excellent user experiences in the software applications that we build. 
+We’re looking for a lead designer to build up our brand identity as the Sandbox expands its presence in the Northeastern community. As design lead, you’ll work closely with our Marketing Director and Executive Director to create branded materials across our website, social media, apparel, and posters. You’ll also work alongside our Core team and the researchers to craft excellent user experiences in the software applications that we build. 
 
-You’ll be part of a rapidly growing club with an opportunity to leave a significant and lasting impact on our brand. You’ll join our community of talented and motivated members, in addition to building connections with the research community at Northeastern.
+You’ll be part of a rapidly growing student organization with an opportunity to leave a significant and lasting impact on our brand. You’ll join our community of talented and motivated members, in addition to building connections with the research community at Northeastern.

--- a/src/content/join/design.md
+++ b/src/content/join/design.md
@@ -7,6 +7,6 @@ formLink: "https://docs.google.com/forms/d/e/1FAIpQLSci8o8K8I4szGhfdqiJ5sAfB9NHg
 role: designer
 ---
 
-We’re looking for a lead designer to build up our brand identity as the Sandbox expands its presence in the Northeastern community. As design lead, you’ll work closely with our Marketing Director and Executive Director to create branded materials across our website, social media, apparel, and posters. You’ll also work alongside our Core team and the researchers to craft excellent user experiences in the software applications that we build. 
+We’re looking for a lead designer to build up our brand identity as the Sandbox expands its presence in the Northeastern community. As design lead, you’ll work closely with our Marketing Director and Executive Director to create branded materials across our website, social media, apparel, and posters. You’ll also work alongside our development team and the researchers to craft excellent user experiences in the software applications that we build. 
 
 You’ll be part of a rapidly growing student organization with an opportunity to leave a significant and lasting impact on our brand. You’ll join our community of talented and motivated members, in addition to building connections with the research community at Northeastern.

--- a/src/content/join/design.md
+++ b/src/content/join/design.md
@@ -7,6 +7,6 @@ formLink: "https://docs.google.com/forms/d/e/1FAIpQLSci8o8K8I4szGhfdqiJ5sAfB9NHg
 role: designer
 ---
 
-We’re looking for a lead designer to build up our brand identity as the Sandbox expands its presence in the Northeastern community. As design lead, you’ll work closely with our Marketing Director and Executive Director to create branded materials across our website, social media, apparel, and posters. You’ll also work alongside our development team and the researchers to craft excellent user experiences in the software applications that we build. 
+We’re looking for a lead designer to build up our brand identity as Sandbox expands its presence in the Northeastern community. As design lead, you’ll work closely with our Marketing Director and Executive Director to create branded materials across our website, social media, apparel, and posters. You’ll also work alongside our development team and the researchers to craft excellent user experiences in the software applications that we build. 
 
 You’ll be part of a rapidly growing student organization with an opportunity to leave a significant and lasting impact on our brand. You’ll join our community of talented and motivated members, in addition to building connections with the research community at Northeastern.

--- a/src/content/join/developer.md
+++ b/src/content/join/developer.md
@@ -11,4 +11,4 @@ role: developer
 
 We’re building a diverse and skilled team of developers with a variety of experiences, interests, and backgrounds to come make some amazing software with us. As a developer, you’ll join a small Agile team and work on a practical software project that will make a significant impact on the work of researchers. Potential projects include web/mobile apps, web scrapers, data processing, and data visualization for professors and PhD students at Northeastern, Yale, and other universities. 
 
-You’ll be part of a rapidly growing club with a wealth of leadership and project management opportunities. You’ll also learn and grow with our community of talented and motivated members, in addition to building connections with the research community at Northeastern.
+You’ll be part of a rapidly growing student organization with a wealth of leadership and project management opportunities. You’ll also learn and grow with our community of talented and motivated members, in addition to building connections with the research community at Northeastern.

--- a/src/content/join/devops.md
+++ b/src/content/join/devops.md
@@ -10,4 +10,4 @@ role: devOps
 
 We’re looking for a developer operations lead to revamp our server infrastructure, improve our continuous integration and deployment system, and overall accelerate our pace of software development. This role is very flexible, and you’ll work closely with our Technical Director to find where your skills and interests are needed most. Your work will have a real impact on the work of researchers, and you’ll get practical experience building out infrastructure in a fast moving, production environment. 
 
-You’ll be part of a rapidly growing club with a wealth of leadership and project management opportunities. You’ll also learn and grow with our community of talented and motivated members, in addition to building connections with the research community at Northeastern.
+You’ll be part of a rapidly growing student organization with a wealth of leadership and project management opportunities. You’ll also learn and grow with our community of talented and motivated members, in addition to building connections with the research community at Northeastern.

--- a/src/content/who/who.json
+++ b/src/content/who/who.json
@@ -3,7 +3,7 @@
   "img2": "./img2.jpg",
   "img3": "./img3.jpg",
   "title1": "Who we are",
-  "p1": "Sandbox is a club at Northeastern University that accelerates research by building custom software applications to enable data collection, visualization, and more. We work closely with researchers across many disciplines to help them best leverage computation in their work.",
+  "p1": "Sandbox is a student organization at Northeastern University that accelerates research by building custom software applications to enable data collection, visualization, and more. We work closely with researchers across many disciplines to help them best leverage computation in their work.",
   "title2": "Why sandbox",
   "p2": "For a researcher that wants software built, finding the right student for the job is a challenge. Sandbox works by assembling a team of dedicated, talented students who have the right skill sets to get the job done. We're committed to finishing projects and are determined to leave a real impact."
 }

--- a/src/pages/join.js
+++ b/src/pages/join.js
@@ -54,8 +54,8 @@ const JoinPage = ({ data }) => {
       <BlueFontSection>
         <Header>JOIN SANDBOX</Header>
         <Subtitle>
-          The Sandbox Core team is currently accepting applications for summer
-          and fall.
+          The Sandbox team is currently accepting applications for summer and
+          fall.
           <br />
           Check out our open roles below.
         </Subtitle>


### PR DESCRIPTION
This PR removes the outdated language "club" and "Core team" from the website when describing Sandbox.