### PR TITLE
Add close dates to bottom of role description

### DIFF
--- a/src/components/JoinPage/JoinContent.js
+++ b/src/components/JoinPage/JoinContent.js
@@ -122,7 +122,7 @@ const JoinContent = ({
       <Wrapper color={color}>
         <ContentHeader color={color} roleName={role} />
         <Body dangerouslySetInnerHTML={{ __html: description }} />
-        <ItalicText>Application closes {closeDate}</ItalicText>
+        {closeDate && <ItalicText>Application closes {closeDate}</ItalicText>}
       </Wrapper>
       <QualitiesHeader>Our Ideal Candidate</QualitiesHeader>
       <QualitiesList qualities={qualities} color={color} />

--- a/src/components/JoinPage/JoinContent.js
+++ b/src/components/JoinPage/JoinContent.js
@@ -80,6 +80,12 @@ const ApplyButtonWrapper = styled.div`
   text-align: center;
 `
 
+const ItalicText = styled.div`
+  font-style: italic;
+  font-size: 1.2em;
+  margin: 15px 0;
+`
+
 const ContentHeader = ({ color, roleName }) => {
   return (
     <ContentHeaderWrapper color={color}>
@@ -103,12 +109,20 @@ const QualitiesList = ({ qualities, color }) => {
   )
 }
 
-const JoinContent = ({ color, role, description, qualities, formLink }) => {
+const JoinContent = ({
+  color,
+  role,
+  description,
+  qualities,
+  formLink,
+  closeDate,
+}) => {
   return (
     <>
       <Wrapper color={color}>
         <ContentHeader color={color} roleName={role} />
         <Body dangerouslySetInnerHTML={{ __html: description }} />
+        <ItalicText>Application closes {closeDate}</ItalicText>
       </Wrapper>
       <QualitiesHeader>Our Ideal Candidate</QualitiesHeader>
       <QualitiesList qualities={qualities} color={color} />

--- a/src/content/join/design.md
+++ b/src/content/join/design.md
@@ -5,6 +5,7 @@ qualities:
   - Wants to create applications that both look great and have an intuitive user experience
 formLink: "https://docs.google.com/forms/d/e/1FAIpQLSci8o8K8I4szGhfdqiJ5sAfB9NHgdv6JGixMNy7lV9aW0EjqA/viewform?usp=sf_link"
 role: designer
+closeDate: August 14th
 ---
 
 We’re looking for a lead designer to build up our brand identity as Sandbox expands its presence in the Northeastern community. As design lead, you’ll work closely with our Marketing Director and Executive Director to create branded materials across our website, social media, apparel, and posters. You’ll also work alongside our development team and the researchers to craft excellent user experiences in the software applications that we build. 

--- a/src/content/join/developer.md
+++ b/src/content/join/developer.md
@@ -7,6 +7,7 @@ qualities:
   - Wants to produce deliverables that make a difference in the world of research
 formLink: "https://docs.google.com/forms/d/e/1FAIpQLSe3ulE49perTqrYLuQhgNVxbL-XewFGuuoZznWihIwJ9g1dpA/viewform?usp=sf_link"
 role: developer
+closeDate: July 31st
 ---
 
 We’re building a diverse and skilled team of developers with a variety of experiences, interests, and backgrounds to come make some amazing software with us. As a developer, you’ll join a small Agile team and work on a practical software project that will make a significant impact on the work of researchers. Potential projects include web/mobile apps, web scrapers, data processing, and data visualization for professors and PhD students at Northeastern, Yale, and other universities. 

--- a/src/content/join/devops.md
+++ b/src/content/join/devops.md
@@ -6,6 +6,7 @@ qualities:
   - Wants to use software to help advance research
 formLink: "https://docs.google.com/forms/d/e/1FAIpQLSfSujdwPQCK6CKwfC9E56J_36IcPgAfbgHSSNgBBwtXqwRvRA/viewform?usp=sf_link"
 role: devOps
+closeDate: August 14th
 ---
 
 We’re looking for a developer operations lead to revamp our server infrastructure, improve our continuous integration and deployment system, and overall accelerate our pace of software development. This role is very flexible, and you’ll work closely with our Technical Director to find where your skills and interests are needed most. Your work will have a real impact on the work of researchers, and you’ll get practical experience building out infrastructure in a fast moving, production environment. 

--- a/src/pages/join.js
+++ b/src/pages/join.js
@@ -71,6 +71,7 @@ const JoinPage = ({ data }) => {
           description={currentRoleData.html}
           formLink={currentRoleData.frontmatter.formLink}
           qualities={currentRoleData.frontmatter.qualities}
+          closeDate={currentRoleData.frontmatter.closeDate}
         />
       </BlueFontSection>
     </Layout>
@@ -87,6 +88,7 @@ export const query = graphql`
             qualities
             formLink
             role
+            closeDate
           }
         }
       }


### PR DESCRIPTION
This PR adds close dates to the bottom of the role descriptions on the join page. It's a simple italic description.