### PR TITLE
Better analytics

### DIFF
--- a/src/components/IndexPage/hero.js
+++ b/src/components/IndexPage/hero.js
@@ -6,7 +6,6 @@ import PropTypes from "prop-types"
 import styled, { keyframes } from "styled-components"
 
 import { SB_ORANGE } from "@colors"
-import { useAmplitudeLogEvent } from "utils/amplitude"
 import banner from "images/sandbox-banner-shadow.svg"
 import Section from "styles/components/Section"
 
@@ -113,7 +112,6 @@ const Arrow = ({ color, scale }) => {
 const Banner = () => <ImgContainer data={banner}>Banner</ImgContainer>
 
 const Hero = ({ title, background }) => {
-  useAmplitudeLogEvent("Visit homepage")
   return (
     <StyledBackgroundImage
       fluid={background.childImageSharp.fluid}

--- a/src/components/IndexPage/project.js
+++ b/src/components/IndexPage/project.js
@@ -5,6 +5,7 @@ import styled from "styled-components"
 
 import { Header, HeaderLineBelow } from "styles/components/Header"
 import Body from "styles/components/Body"
+import { amplitudeLogEvent } from "utils/amplitude"
 import { SB_ORANGE, SB_NAVY_RGBA } from "@colors"
 
 const CardBG = styled(BackgroundImage)`
@@ -135,6 +136,7 @@ class Project extends Component {
   }
 
   openGithub = () => {
+    amplitudeLogEvent("click projet", { project: this.props.title })
     var win = window.open(this.props.github, "_blank")
     win.focus()
   }

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react"
 import { Link } from "gatsby"
 import PropTypes from "prop-types"
 import styled, { css } from "styled-components"
-import { amplitudeLogEvent } from "utils/amplitude"
+import { useAmplitudeLogEvent } from "utils/amplitude"
 
 import { SB_NAVY, SB_ORANGE_RGBA } from "@colors"
 import { SectionContent } from "styles/components/Section"
@@ -67,9 +67,7 @@ const Button = styled(Link)`
 
 const Nav = ({ page, pages }) => {
   const [atTop, setAtTop] = useState(true)
-  useEffect(() => {
-    amplitudeLogEvent("Page load", { page: page })
-  }, [])
+  useAmplitudeLogEvent("Page load", { page: page })
 
   const handleScroll = () => {
     const pageY = document.body.scrollTop || document.documentElement.scrollTop

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
 import PropTypes from "prop-types"
 import styled, { css, keyframes } from "styled-components"
+import { useAmplitudeLogEvent } from "utils/amplitude"
 
 import { SB_NAVY, SB_ORANGE_RGBA } from "@colors"
 import { SectionContent } from "styles/components/Section"
@@ -85,6 +86,7 @@ const Button = styled.a`
 const Nav = ({ page, pages }) => {
   const [atTop, setAtTop] = useState(true)
   const [hasScrolled, setHasScrolled] = useState(false)
+  useAmplitudeLogEvent("Visit", { page: page })
 
   const handleScroll = () => {
     const pageY = document.body.scrollTop || document.documentElement.scrollTop

--- a/src/pages/apply.js
+++ b/src/pages/apply.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { graphql } from "gatsby"
 import styled from "styled-components"
 
@@ -8,6 +8,7 @@ import ApplyContent from "components/ApplyPage/ApplyContent"
 import Layout from "components/layout"
 import SEO from "components/seo"
 import Section from "styles/components/Section"
+import { amplitudeLogEvent } from "utils/amplitude"
 
 export const ROLE_COLOR_MAPPING = {
   developer: SB_ORANGE,
@@ -42,6 +43,11 @@ const Subtitle = styled.h3`
 
 const ApplyPage = ({ data }) => {
   const [selectedRole, setSelectedRole] = useState("developer")
+
+  useEffect(() => {
+    amplitudeLogEvent("Visit", { page: `apply#${selectedRole}` })
+  }, [selectedRole])
+
   const currentRoleData = data.allMarkdownRemark.edges.find(
     roleData => roleData.node.frontmatter.role === selectedRole
   ).node

--- a/src/utils/amplitude.js
+++ b/src/utils/amplitude.js
@@ -11,13 +11,16 @@ export const amplitudeLogEvent = (eventName, props) => {
   a.getInstance().logEvent(eventName, props)
 }
 
-export const useAmplitudeLogEvent = eventName => {
+export const useAmplitudeLogEvent = (eventName, props) => {
   useEffect(() => {
     if (process.env.NODE_ENV !== "development") {
       amplitudeInit()
-      amplitudeLogEvent(eventName, { hostname: window.location.hostname })
+      amplitudeLogEvent(eventName, {
+        ...props,
+        hostname: window.location.hostname,
+      })
     } else {
-      console.log(`Amplitude event ${eventName} triggered.`)
+      console.log(`Amplitude event ${eventName} triggered with props:`, props)
     }
   }, [])
 }

--- a/src/utils/amplitude.js
+++ b/src/utils/amplitude.js
@@ -8,19 +8,19 @@ export const amplitudeInit = () => {
 }
 
 export const amplitudeLogEvent = (eventName, props) => {
-  a.getInstance().logEvent(eventName, props)
+  if (process.env.NODE_ENV !== "development") {
+    amplitudeInit()
+    amplitudeLogEvent(eventName, {
+      ...props,
+      hostname: window.location.hostname,
+    })
+  } else {
+    console.log(`Amplitude event ${eventName} triggered with props:`, props)
+  }
 }
 
 export const useAmplitudeLogEvent = (eventName, props) => {
   useEffect(() => {
-    if (process.env.NODE_ENV !== "development") {
-      amplitudeInit()
-      amplitudeLogEvent(eventName, {
-        ...props,
-        hostname: window.location.hostname,
-      })
-    } else {
-      console.log(`Amplitude event ${eventName} triggered with props:`, props)
-    }
+    amplitudeLogEvent(eventName, props)
   }, [])
 }

--- a/src/utils/amplitude.js
+++ b/src/utils/amplitude.js
@@ -7,10 +7,10 @@ export const amplitudeInit = () => {
   })
 }
 
-export const amplitudeLogEvent = (eventName, props) => {
+export const amplitudeLogEvent = (eventName, props = {}) => {
   if (process.env.NODE_ENV !== "development") {
     amplitudeInit()
-    amplitudeLogEvent(eventName, {
+    a.getInstance().logEvent(eventName, {
       ...props,
       hostname: window.location.hostname,
     })


### PR DESCRIPTION
Logging "Page load" for each page, with an event parameter containing which page (index, apply team)

Logging clicks on the project cards. Curious if anyone actually does that.

Logging "View role" for each role that gets viewed, with a parameter containing the role.

When a user clicks the apply button, it will log "Page load" for the apply page, then also "View role" for designer, because that is the default role that opens up. After that, when they click through the roles, it'll just log which role they view.